### PR TITLE
feat/f-13 #13

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/example/beeye/ui/view/home/HomePermissionDialog.kt
+++ b/app/src/main/java/com/example/beeye/ui/view/home/HomePermissionDialog.kt
@@ -6,9 +6,9 @@ import android.view.View
 import android.view.ViewGroup
 import com.example.beeye.R
 import com.example.beeye.common.base.BaseDialog
-import com.example.beeye.databinding.FragmentHomeCameraPermissionDialogBinding
+import com.example.beeye.databinding.FragmentHomePermissionDialogBinding
 
-class HomeCameraPermissionDialog : BaseDialog<FragmentHomeCameraPermissionDialogBinding>(R.layout.fragment_home_camera_permission_dialog) {
+class HomePermissionDialog : BaseDialog<FragmentHomePermissionDialogBinding>(R.layout.fragment_home_permission_dialog) {
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -22,5 +22,6 @@ class HomeCameraPermissionDialog : BaseDialog<FragmentHomeCameraPermissionDialog
         return binding.root
     }
 
-    override fun getViewBinding() = FragmentHomeCameraPermissionDialogBinding.inflate(layoutInflater)
+    override fun getViewBinding() = FragmentHomePermissionDialogBinding.inflate(layoutInflater)
+
 }

--- a/app/src/main/res/layout/fragment_home_permission_dialog.xml
+++ b/app/src/main/res/layout/fragment_home_permission_dialog.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="@drawable/bd_common_btn"
-    tools:context=".ui.view.home.HomeCameraPermissionDialog">
+    tools:context=".ui.view.home.HomePermissionDialog">
 
     <TextView
         android:id="@+id/dialog_camera_txt"
@@ -14,11 +14,11 @@
         android:textColor="@color/yellow"
         android:layout_marginTop="30dp"
         android:gravity="center"
+        android:text="@string/dialog_permission"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@id/dialog_camera_btn"
         app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        android:text="@string/dialog_camera_permission" />
+        app:layout_constraintRight_toRightOf="parent"/>
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/dialog_camera_btn"
@@ -31,6 +31,7 @@
         android:layout_marginEnd="15dp"
         android:layout_marginTop="20dp"
         android:layout_marginBottom="30dp"
+        android:gravity="center"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="home_btn_gallery">이미지</string>
 
     <!-- 다이얼로그   -->
-    <string name="dialog_camera_permission"><b>카메라</b>를 활용하려면 \n 해당 권한이 필요합니다!🙇‍</string>
+    <string name="dialog_permission">해당 기능을 활용하려면 <b>권한</b>이 필요합니다!🙇‍</string>
     <string name="dialog_btn_yes">확인</string>
 
 </resources>


### PR DESCRIPTION
### Summary✔️
홈화면에서 이미지 버튼 클릭 시,
갤러리 호출 및 사진 bitmap으로 받아오기

### Key Changes✨
- [x] 사용자 권한 확인
- [x] 갤러리 호출
- [x] 사진 bitmap으로 받아오기
- [x] 홈화면에서 공통으로 사용할 dialog 업데이트

### Result👀
<img width="304" alt="스크린샷 2023-02-17 오후 11 00 09" src="https://user-images.githubusercontent.com/64644738/219675833-d48b1b9f-7bb3-44b0-ae3d-39398de42452.png">
<img width="302" alt="스크린샷 2023-02-17 오후 11 00 47" src="https://user-images.githubusercontent.com/64644738/219675947-6acc685c-a325-467c-9c23-27852f07a238.png">

파일 접근 권한이 android 13부터 달라져 READ_MEDIA_IMAGES로 변경되었다.
또한, 갤러리에서 가져온 사진 uri를 bitmap으로 변환하는 과정이 sdk 버전에 따라 달라 버전 처리를 진행하였다.


### Close Issue🔨
resolve #13
